### PR TITLE
fix: NodeSize error when inserting image at end of document

### DIFF
--- a/projects/angular-tiptap-editor/src/lib/services/ate-image.service.ts
+++ b/projects/angular-tiptap-editor/src/lib/services/ate-image.service.ts
@@ -58,7 +58,13 @@ export class AteImageService {
   /** Insert a new image and ensure it's selected */
   insertImage(editor: Editor, imageData: AteImageData): void {
     const { from } = editor.state.selection;
-    editor.chain().focus().setResizableImage(imageData).setNodeSelection(from).run();
+
+    // Insert the image at the current cursor position
+    editor.chain().focus().setResizableImage(imageData).run();
+
+    // Select the newly inserted node (separate command to avoid position shift issues)
+    // The node is at the position where we inserted it
+    editor.commands.setNodeSelection(from);
   }
 
   /** Update attributes of the currently active image */


### PR DESCRIPTION
Fixes #29 

Splitting the insertion and node selection into separate commands prevents potential position shift issues that can occur when they are chained together.